### PR TITLE
Add backend package configuration and update tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+*.log
+frontend/build
+backend/node_modules/

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "certification-tracker-backend",
+  "version": "1.0.0",
+  "description": "Backend server for certification tracker app",
+  "type": "module",
+  "scripts": {
+    "start": "node server.mjs"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders Certification Overview heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headingElement = screen.getByText(/Certification Overview/i);
+  expect(headingElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- add root gitignore and backend package configuration for express server
- fix frontend test to check dashboard heading

## Testing
- `CI=true npm test --prefix frontend -- --watchAll=false`
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*
- `node backend/server.mjs` *(fails: Cannot find package 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68a22ca709a08325b82e90b9142952d9