### PR TITLE
fix: guard against missing certification records in dashboard

### DIFF
--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,8 +1,21 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('renders dashboard header', async () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const header = await screen.findByText(/Salesforce Cert Dashboard/i);
+  expect(header).toBeInTheDocument();
 });

--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -18,7 +18,7 @@ function Dashboard({ data }) {
 
   const flattenCerts = () => {
     return data.flatMap(user => {
-      return user.RelatedCertificationStatus?.records.map(cert => ({
+      return user.RelatedCertificationStatus?.records?.map(cert => ({
         email: user.email,
         name: user.Name,
         city: user.City,


### PR DESCRIPTION
## Summary
- avoid crashing when a user lacks RelatedCertificationStatus records by checking for missing data
- replace placeholder test with a fetch-mocked test for dashboard header

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68a2227e9eb483259c0e18f0fe104c7d