### PR TITLE
Add role-aware certification cache and self-service tools

### DIFF
--- a/backend/cache/certCache.json
+++ b/backend/cache/certCache.json
@@ -1,98 +1,16 @@
 [
   {
     "email": "ankush@example.com",
-    "Name": "Ankush Kumar",
-    "City": "BEGUSARAI",
-    "State": "IN-BR",
-    "Country": "IN",
-    "MappingKey": "RSC3PHo9m/grxPUkGH8KATqvM0hexVIlw62fdbMDhvMkMSMvxmnvqHCb9+Fvll+K",
-    "RelatedCertificationStatus": {
-      "totalSize": 4,
-      "records": [
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Agentforce Specialist",
-          "CertificationDate": "May 22, 2025",
-          "RelatedCertificationType": {
-            "Image": "https://drm.my.salesforce.com/servlet/servlet.ImageServer?id=015KV00000B8Hnp&oid=00DF0000000gZsu&lastMod=1723530339000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified AI Associate",
-          "CertificationDate": "December 12, 2024",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000BEqgH&oid=00DF0000000gZsu&lastMod=1693557495000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Marketing Cloud Email Specialist",
-          "CertificationDate": "June 29, 2022",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5Mu9&oid=00DF0000000gZsu&lastMod=1617268670000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Platform Developer I",
-          "CertificationDate": "March 28, 2022",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5Mtz&oid=00DF0000000gZsu&lastMod=1617268528000"
-          }
-        }
-      ]
-    }
+    "role": "Consultant",
+    "searchString": "lccOVPDlqw3jPtvAezIqGXuhfy3XpqajC5iR2rfjXwmvBiIl4tdfh57jE9AjkaQ7",
+    "certifications": [],
+    "lastUpdated": null
   },
   {
     "email": "Sachin@example.com",
-    "Name": "Sachin Sharma",
-    "City": "Mumbai",
-    "State": "IN-MH",
-    "Country": "IN",
-    "MappingKey": "h0Sfc/LeJRo4IDKsr/vXWJBNfmIjXt7Vbk9hIiTIUZ6yo05xT2Zjw4e2QU0dxf1J",
-    "RelatedCertificationStatus": {
-      "totalSize": 6,
-      "records": [
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Data Cloud Consultant",
-          "CertificationDate": "December 27, 2024",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000BEqgM&oid=00DF0000000gZsu&lastMod=1693557540000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified AI Associate",
-          "CertificationDate": "November 24, 2024",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000BEqgH&oid=00DF0000000gZsu&lastMod=1693557495000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Marketing Cloud Developer",
-          "CertificationDate": "December 20, 2023",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5Mu3&oid=00DF0000000gZsu&lastMod=1617274584000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Marketing Cloud Consultant",
-          "CertificationDate": "March 31, 2023",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5Mtk&oid=00DF0000000gZsu&lastMod=1617268737000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Marketing Cloud Administrator",
-          "CertificationDate": "October 29, 2022",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5MuD&oid=00DF0000000gZsu&lastMod=1617267728000"
-          }
-        },
-        {
-          "ExternalCertificationTypeName": "Salesforce Certified Marketing Cloud Email Specialist",
-          "CertificationDate": "July 31, 2021",
-          "RelatedCertificationType": {
-            "Image": "https://drm.file.force.com/servlet/servlet.ImageServer?id=0153k00000A5Mu9&oid=00DF0000000gZsu&lastMod=1617268670000"
-          }
-        }
-      ]
-    }
+    "role": "Consultant",
+    "searchString": "S3cq13Nf65+CNhqhOP4aVZtf+dIYW9cGiCKw1V3sHoSmDBKW7nZwPDefa75jSclA",
+    "certifications": [],
+    "lastUpdated": null
   }
 ]

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.18.2",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "multer": "^1.4.5"
   }
 }

--- a/backend/server.mjs
+++ b/backend/server.mjs
@@ -3,6 +3,7 @@ import cors from 'cors';
 import fs from 'fs/promises';
 import path from 'path';
 import fetch from 'node-fetch';
+import multer from 'multer';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -10,39 +11,48 @@ const __dirname = path.dirname(__filename);
 
 const app = express();
 app.use(cors());
+app.use(express.json());
+
+const upload = multer({ dest: path.join(__dirname, 'uploads') });
 
 const CACHE_FILE = path.join(__dirname, 'cache', 'certCache.json');
-const USER_FILE = path.join(__dirname, '..', 'frontend', 'public', 'data', 'cert-users.txt');
 const BASE_URL = 'https://drm.my.salesforce-sites.com/services/apexrest/credential';
 
-async function readUserList() {
-  const content = await fs.readFile(USER_FILE, 'utf-8');
-  const lines = content.trim().split('\n').slice(1);
-  return lines
-    .map(line => {
-      const [email, searchString] = line.split(',');
-      if (email && searchString) return { email: email.trim(), searchString: searchString.trim() };
-      return null;
-    })
-    .filter(entry => entry !== null);
+// Define mandatory certifications per role
+const ROLE_REQUIREMENTS = {
+  Consultant: ['Sales Cloud Consultant', 'Service Cloud Consultant', 'Platform App Builder'],
+  Analyst: ['Administrator', 'Platform Developer I', 'Data Cloud Consultant'],
+  Architect: ['Application Architect', 'System Architect', 'Identity and Access Management Architect'],
+  Developer: ['Platform Developer I', 'Platform Developer II', 'JavaScript Developer I'],
+  Admin: ['Administrator', 'Advanced Administrator'],
+};
+
+async function readCache() {
+  try {
+    const data = await fs.readFile(CACHE_FILE, 'utf-8');
+    return JSON.parse(data);
+  } catch {
+    return [];
+  }
 }
 
-async function fetchCertification(searchString) {
-  const url = `${BASE_URL}?searchString=${encodeURIComponent(searchString)}&languageLocaleKey=en`;
+async function writeCache(cache) {
+  await fs.writeFile(CACHE_FILE, JSON.stringify(cache, null, 2));
+}
+
+async function fetchCertification(searchString, role) {
+  let url = `${BASE_URL}?searchString=${encodeURIComponent(searchString)}&languageLocaleKey=en`;
+  if (role === 'Admin') {
+    // Example of role-based branching logic
+    url += '&admin=true';
+  }
   try {
     const response = await fetch(url);
     const text = await response.text();
-    console.log("🔎 Raw response for", searchString, ":\n", text.slice(0, 500));
-
-    // Try to parse as full JSON (not from XML tag)
     const parsed = JSON.parse(text);
-
     if (parsed.status !== 'success' || !parsed.data?.[0]?.jsonResponse) {
-      console.warn(`⚠️ Invalid or missing data for searchString: ${searchString}`);
       return null;
     }
-
-    // Extract and parse nested JSON string
     const innerJson = JSON.parse(parsed.data[0].jsonResponse);
     return innerJson;
   } catch (err) {
@@ -51,12 +61,58 @@ async function fetchCertification(searchString) {
   }
 }
 
-
+function mapCerts(apiRecord) {
+  const records = apiRecord?.RelatedCertificationStatus?.records || [];
+  return records.map(r => ({
+    provider: 'Salesforce',
+    name: r.ExternalCertificationTypeName || '',
+    earnedAt: r.CertificationDate || '',
+    expiresAt: null,
+    status: 'active',
+    meta: r.RelatedCertificationType || {},
+  }));
+}
 
 app.get('/api/get-cache', async (req, res) => {
+  const cache = await readCache();
+  res.json(cache);
+});
+
+app.get('/api/users/:email', async (req, res) => {
+  const cache = await readCache();
+  const user = cache.find(u => u.email === req.params.email);
+  if (!user) return res.status(404).json({ error: 'User not found' });
+  res.json(user);
+});
+
+app.put('/api/users', async (req, res) => {
   try {
-    const cache = await fs.readFile(CACHE_FILE, 'utf-8');
-    res.json(JSON.parse(cache));
+    const { email, role, searchString, certifications = [] } = req.body;
+    if (!email || !role) {
+      return res.status(400).json({ error: 'email and role required' });
+    }
+    const required = ROLE_REQUIREMENTS[role] || [];
+    const names = certifications.map(c => c.name);
+    const missing = required.filter(r => !names.includes(r));
+    if (missing.length) {
+      return res.status(400).json({ error: `Missing mandatory certifications: ${missing.join(', ')}` });
+    }
+    const cache = await readCache();
+    const idx = cache.findIndex(u => u.email === email);
+    const entry = {
+      email,
+      role,
+      searchString: searchString || (idx >= 0 ? cache[idx].searchString : ''),
+      certifications,
+      lastUpdated: new Date().toISOString(),
+    };
+    if (idx >= 0) {
+      cache[idx] = entry;
+    } else {
+      cache.push(entry);
+    }
+    await writeCache(cache);
+    res.json(entry);
   } catch (err) {
     res.status(500).json({ error: err.message });
   }
@@ -64,28 +120,64 @@ app.get('/api/get-cache', async (req, res) => {
 
 app.post('/api/refresh-cache', async (req, res) => {
   try {
-    const users = await readUserList();
-    console.log(`🔁 Refreshing data for ${users.length} users...`);
-
+    const users = await readCache();
     const results = [];
-
     for (const user of users) {
-      console.log(`→ Fetching for ${user.email}`);
-      const result = await fetchCertification(user.searchString);
+      const result = await fetchCertification(user.searchString, user.role);
       if (result && result.data && result.data[0]) {
-        results.push({ email: user.email, ...result.data[0] });
+        const certs = mapCerts(result.data[0]);
+        results.push({ ...user, certifications: certs, lastUpdated: new Date().toISOString() });
       } else {
-        console.warn(`❌ No result for ${user.email}`);
+        results.push({ ...user, certifications: [], lastUpdated: new Date().toISOString() });
       }
     }
-
-    await fs.writeFile(CACHE_FILE, JSON.stringify(results, null, 2));
-    console.log(`✅ Cache updated: ${results.length} records saved.`);
+    await writeCache(results);
     res.json({ success: true, count: results.length });
   } catch (err) {
-    console.error(`❌ Error refreshing cache:`, err.message);
     res.status(500).json({ error: err.message });
   }
+});
+
+app.post('/api/upload-csv', upload.single('file'), async (req, res) => {
+  try {
+    const content = await fs.readFile(req.file.path, 'utf-8');
+    await fs.unlink(req.file.path);
+    const lines = content.trim().split('\n').slice(1);
+    let processed = 0;
+    let success = 0;
+    const errors = [];
+    const cache = await readCache();
+    for (const [index, line] of lines.entries()) {
+      processed++;
+      const [email, role, searchString] = line.split(',');
+      if (email && role && searchString) {
+        const entry = {
+          email: email.trim(),
+          role: role.trim(),
+          searchString: searchString.trim(),
+          certifications: [],
+          lastUpdated: null,
+        };
+        const existingIdx = cache.findIndex(u => u.email === entry.email);
+        if (existingIdx >= 0) {
+          cache[existingIdx] = { ...cache[existingIdx], ...entry };
+        } else {
+          cache.push(entry);
+        }
+        success++;
+      } else {
+        errors.push({ row: index + 2, error: 'Invalid row' });
+      }
+    }
+    await writeCache(cache);
+    res.json({ processed, success, errors });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/roles', (req, res) => {
+  res.json(ROLE_REQUIREMENTS);
 });
 
 const PORT = 4000;

--- a/frontend/src/components/ComplianceReport.jsx
+++ b/frontend/src/components/ComplianceReport.jsx
@@ -1,15 +1,5 @@
 import React, { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 
-// Define roles and their mandatory certifications
-// This ROLES_CONFIG should ideally be imported from a shared constants file or fetched from a backend
-const ROLES_CONFIG = {
-  'Consultant': ['Sales Cloud Consultant', 'Service Cloud Consultant', 'Platform App Builder'],
-  'Analyst': ['Administrator', 'Platform Developer I', 'Data Cloud Consultant'],
-  'Architect': ['Application Architect', 'System Architect', 'Identity and Access Management Architect'],
-  'Developer': ['Platform Developer I', 'Platform Developer II', 'JavaScript Developer I'],
-  'Admin': ['Administrator', 'Advanced Administrator'],
-};
-
 // Simulate loading PEP definition from a text file
 const fetchPepDefinition = async () => {
   await new Promise(resolve => setTimeout(resolve, 300));

--- a/frontend/src/components/SelfServiceForm.js
+++ b/frontend/src/components/SelfServiceForm.js
@@ -1,0 +1,133 @@
+import React, { useState, useEffect } from 'react';
+
+const SelfServiceForm = () => {
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState('');
+  const [certifications, setCertifications] = useState([]);
+  const [roles, setRoles] = useState({});
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:4000/api/roles')
+      .then(res => res.json())
+      .then(setRoles)
+      .catch(() => {});
+  }, []);
+
+  const fetchExisting = async () => {
+    setMessage('');
+    const res = await fetch(`http://localhost:4000/api/users/${encodeURIComponent(email)}`);
+    if (res.ok) {
+      const user = await res.json();
+      setRole(user.role);
+      setCertifications(user.certifications || []);
+    } else {
+      setMessage('User not found');
+    }
+  };
+
+  const addCert = () => {
+    const available = roles[role] || [];
+    setCertifications([
+      ...certifications,
+      {
+        provider: 'Salesforce',
+        name: available[0] || '',
+        earnedAt: '',
+        expiresAt: '',
+        status: 'active',
+        meta: {},
+      },
+    ]);
+  };
+
+  const updateCert = (idx, field, value) => {
+    const updated = certifications.map((c, i) => (i === idx ? { ...c, [field]: value } : c));
+    setCertifications(updated);
+  };
+
+  const removeCert = idx => {
+    setCertifications(certifications.filter((_, i) => i !== idx));
+  };
+
+  const submit = async () => {
+    setMessage('');
+    const res = await fetch('http://localhost:4000/api/users', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, role, certifications }),
+    });
+    const json = await res.json();
+    if (res.ok) {
+      setMessage('Saved');
+    } else {
+      setMessage(json.error || 'Error');
+    }
+  };
+
+  const roleOptions = Object.keys(roles);
+  const availableCerts = roles[role] || [];
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h2 className="text-xl font-bold mb-4">Update Certifications</h2>
+      <div className="mb-2">
+        <label className="block text-sm">Email</label>
+        <input className="border p-2 w-full" value={email} onChange={e => setEmail(e.target.value)} />
+      </div>
+      <div className="mb-2">
+        <label className="block text-sm">Role</label>
+        <select className="border p-2 w-full" value={role} onChange={e => setRole(e.target.value)}>
+          <option value="">Select role</option>
+          {roleOptions.map(r => (
+            <option key={r} value={r}>
+              {r}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-2">
+        <button className="bg-gray-200 px-2 py-1 mr-2" onClick={fetchExisting}>
+          Fetch Existing Data
+        </button>
+        <button className="bg-green-200 px-2 py-1" onClick={addCert} disabled={!role}>
+          Add Certification
+        </button>
+      </div>
+      {certifications.map((cert, idx) => (
+        <div key={idx} className="mb-2 border p-2">
+          <div className="flex mb-1">
+            <select
+              className="border p-1 mr-2 flex-grow"
+              value={cert.name}
+              onChange={e => updateCert(idx, 'name', e.target.value)}
+            >
+              {availableCerts.map(c => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            <input
+              type="date"
+              className="border p-1 flex-grow"
+              value={cert.earnedAt}
+              onChange={e => updateCert(idx, 'earnedAt', e.target.value)}
+            />
+            <button className="ml-2 text-red-500" onClick={() => removeCert(idx)}>
+              X
+            </button>
+          </div>
+        </div>
+      ))}
+      <div className="mt-4">
+        <button className="bg-blue-600 text-white px-4 py-2" onClick={submit}>
+          Submit Updates
+        </button>
+      </div>
+      {message && <p className="mt-2 text-sm">{message}</p>}
+    </div>
+  );
+};
+
+export default SelfServiceForm;


### PR DESCRIPTION
## Summary
- Store certification data in structured `certCache.json` with role awareness and audit timestamp
- Support CSV migration, user updates, role-based validation, and mandatory cert configuration via backend API
- Add React self-service form and fetch role definitions from backend

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/multer)
- `npm test` in `backend` (fails: Missing script: "test")
- `npm test` in `frontend` (no tests run; manual termination)


------
https://chatgpt.com/codex/tasks/task_e_68a2b75644648325b299908908e6b84c